### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+# The ikobconfig and ikobrunner GUI require tk.
+RUN apt-get update -y
+RUN apt-get install tk -y
+
+WORKDIR /app
+COPY . /app
+
+# Install ikob.
+RUN pip install --upgrade pip
+RUN pip install -e .[dev]


### PR DESCRIPTION
Basic Dockerfile configuration for IKOB to build and run IKOB. It also supports running both GUI applications ikobconfig and ikobrunner.

Closes #5.