### PR TITLE
Remove unused functions Berekeningen.py and strip 'bereken' prefix

### DIFF
--- a/src/ikob/Berekeningen.py
+++ b/src/ikob/Berekeningen.py
@@ -1,7 +1,7 @@
 import ikob.Routines as Routines
 
 
-def bereken_concurrentie(Matrix, Beroepsbevolking, Bereik, inkgr, inkgroepen):
+def concurrentie(Matrix, Beroepsbevolking, Bereik, inkgr, inkgroepen):
     Dezegroeplijst = []
     Beroepsbevolkingtrans = Routines.transponeren(Beroepsbevolking)
     for i in range(len(Matrix)):
@@ -15,7 +15,7 @@ def bereken_concurrentie(Matrix, Beroepsbevolking, Bereik, inkgr, inkgroepen):
     return Dezegroeplijst
 
 
-def bereken_potenties(Matrix, Inwonerstrans, gr, Groepen):
+def potenties(Matrix, Inwonerstrans, gr, Groepen):
     Dezegroeplijst = []
     for i in range(len(Matrix)):
         Gewogenmatrix = []

--- a/src/ikob/Concurrentieomarbeidsplaatsen.py
+++ b/src/ikob/Concurrentieomarbeidsplaatsen.py
@@ -96,7 +96,7 @@ def concurrentie_om_arbeidsplaatsen(config, datasource):
 
                                 Fietsmatrix = datasource.read_csv('Gewichten', f'{mod}_vk', ds, vk=vkklad, regime=regime, mot=mot)
                                 Bereik = datasource.read_csv('Herkomsten', "Totaal", ds, mot=mot, mod=mod, ink=inkgr)
-                                Dezegroeplijst = Berekeningen.bereken_concurrentie ( Fietsmatrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
+                                Dezegroeplijst = Berekeningen.concurrentie ( Fietsmatrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
 
                                 for i in range ( 0, len ( Fietsmatrix ) ):
                                     if Inkomensverdeling[i][inkgroepen.index(inkgr)]>0:
@@ -111,7 +111,7 @@ def concurrentie_om_arbeidsplaatsen(config, datasource):
                                     for srtbr in soortbrandstof:
                                         Matrix = datasource.read_csv('Gewichten', f"{String}_vk", ds, vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
                                         Bereik = datasource.read_csv('Herkomsten', "Totaal", ds, mot=mot, mod=mod, ink=inkgr)
-                                        Dezegroeplijst1 = Berekeningen.bereken_concurrentie ( Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
+                                        Dezegroeplijst1 = Berekeningen.concurrentie ( Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
                                         if srtbr == 'elektrisch':
                                             K = percentageelektrisch.get(inkgr) / 100
                                             logger.debug('aandeel elektrisch is %s', K)
@@ -129,7 +129,7 @@ def concurrentie_om_arbeidsplaatsen(config, datasource):
                                 else:
                                     Matrix = datasource.read_csv('Gewichten', f"{String}_vk", ds, vk=vk, ink=ink, regime=regime, mot=mot)
                                     Bereik = datasource.read_csv('Herkomsten', "Totaal", ds, mot=mot, mod=mod, ink=inkgr)
-                                    Dezegroeplijst = Berekeningen.bereken_concurrentie(Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
+                                    Dezegroeplijst = Berekeningen.concurrentie(Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
                                     for i in range(len(Matrix)):
                                         if Inkomensverdeling[i][inkgroepen.index(inkgr)]>0:
                                             Bijhoudklad = Dezegroeplijst[i] * Verdelingsmatrix[i][Groepen.index(gr)]/\
@@ -139,7 +139,7 @@ def concurrentie_om_arbeidsplaatsen(config, datasource):
                                 String = Routines.enkelegroep(mod, gr)
                                 Matrix = datasource.read_csv('Gewichten', f"{String}_vk", ds, vk=vk, ink=ink, regime=regime, mot=mot)
                                 Bereik = datasource.read_csv('Herkomsten', "Totaal", ds, mot=mot, mod=mod, ink=inkgr)
-                                Dezegroeplijst = Berekeningen.bereken_concurrentie(Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
+                                Dezegroeplijst = Berekeningen.concurrentie(Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
                                 for i in range(len(Matrix)):
                                     if Inkomensverdeling[i][inkgroepen.index(inkgr)] > 0:
                                         Bijhoudklad = Dezegroeplijst[i] * Verdelingsmatrix[i][Groepen.index(gr)] / \
@@ -154,7 +154,7 @@ def concurrentie_om_arbeidsplaatsen(config, datasource):
                                     for srtbr in soortbrandstof:
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
                                         Bereik = datasource.read_csv('Herkomsten', "Totaal", ds, mot=mot, mod=mod, ink=inkgr)
-                                        Dezegroeplijst1 = Berekeningen.bereken_concurrentie ( Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
+                                        Dezegroeplijst1 = Berekeningen.concurrentie ( Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
                                         if srtbr == 'elektrisch':
                                             K = percentageelektrisch.get(inkgr)/100
                                             DezegroeplijstE = [x * K for x in Dezegroeplijst1]
@@ -170,7 +170,7 @@ def concurrentie_om_arbeidsplaatsen(config, datasource):
                                 else:
                                     Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot)
                                     Bereik = datasource.read_csv('Herkomsten', "Totaal", ds, mot=mot, mod=mod, ink=inkgr)
-                                    Dezegroeplijst = Berekeningen.bereken_concurrentie(Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
+                                    Dezegroeplijst = Berekeningen.concurrentie(Matrix, Arbeidsplaatsen, Bereik, inkgr, inkgroepen)
                                     for i in range (len(Matrix)):
                                         if Inkomensverdeling[i][inkgroepen.index(inkgr)]>0:
                                             Bijhoudklad = Dezegroeplijst[i] * Verdelingsmatrix[i][Groepen.index(gr)]/\

--- a/src/ikob/Concurrentieominwoners.py
+++ b/src/ikob/Concurrentieominwoners.py
@@ -99,7 +99,7 @@ def concurrentie_om_inwoners(config, datasource):
 
                                     Fietsmatrix = datasource.read_csv('Gewichten', f'{mod}_vk', ds, vk=vkklad, regime=regime, mot=mot)
                                     Bereik = datasource.read_csv(abg, "Totaal", ds, mod=mod, ink=inkgr, mot=mot, subtopic="Bestemmingen")
-                                    Dezegroeplijst = Berekeningen.bereken_concurrentie ( Fietsmatrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
+                                    Dezegroeplijst = Berekeningen.concurrentie ( Fietsmatrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
 
                                     for i in range ( 0, len ( Fietsmatrix ) ):
                                         if Inkomensverdeling[i][inkgroepen.index(inkgr)]>0:
@@ -114,7 +114,7 @@ def concurrentie_om_inwoners(config, datasource):
                                         for srtbr in soortbrandstof:
                                             Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
                                             Bereik = datasource.read_csv(abg, "Totaal", ds, mod=mod, ink=inkgr, mot=mot, subtopic="Bestemmingen")
-                                            Dezegroeplijst1 = Berekeningen.bereken_concurrentie ( Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
+                                            Dezegroeplijst1 = Berekeningen.concurrentie ( Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
                                             if srtbr == 'elektrisch':
                                                 K = percentageelektrisch.get(inkgr) / 100
                                                 logger.debug('aandeel elektrisch is %s', K)
@@ -132,7 +132,7 @@ def concurrentie_om_inwoners(config, datasource):
                                     else:
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot)
                                         Bereik = datasource.read_csv(abg, "Totaal", ds, mod=mod, ink=inkgr, mot=mot, subtopic="Bestemmingen")
-                                        Dezegroeplijst = Berekeningen.bereken_concurrentie(Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
+                                        Dezegroeplijst = Berekeningen.concurrentie(Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
                                         for i in range(len(Matrix)):
                                             if Inkomensverdeling[i][inkgroepen.index(inkgr)]>0:
                                                 Bijhoudklad = Dezegroeplijst[i] * Verdelingsmatrix[i][Groepen.index(gr)]/\
@@ -142,7 +142,7 @@ def concurrentie_om_inwoners(config, datasource):
                                     String = Routines.enkelegroep(mod, gr)
                                     Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot)
                                     Bereik = datasource.read_csv(abg, "Totaal", ds, mod=mod, ink=inkgr, mot=mot, subtopic="Bestemmingen")
-                                    Dezegroeplijst = Berekeningen.bereken_concurrentie(Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
+                                    Dezegroeplijst = Berekeningen.concurrentie(Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
                                     for i in range(len(Matrix)):
                                         if Inkomensverdeling[i][inkgroepen.index(inkgr)] > 0:
                                             Bijhoudklad = Dezegroeplijst[i] * Verdelingsmatrix[i][Groepen.index(gr)] / \
@@ -157,7 +157,7 @@ def concurrentie_om_inwoners(config, datasource):
                                         for srtbr in soortbrandstof:
                                             Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
                                             Bereik = datasource.read_csv(abg, "Totaal", ds, mod=mod, ink=inkgr, mot=mot, subtopic="Bestemmingen")
-                                            Dezegroeplijst1 = Berekeningen.bereken_concurrentie ( Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
+                                            Dezegroeplijst1 = Berekeningen.concurrentie ( Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
                                             if srtbr == 'elektrisch':
                                                 K = percentageelektrisch.get(inkgr)/100
                                                 DezegroeplijstE = [x * K for x in Dezegroeplijst1]
@@ -173,7 +173,7 @@ def concurrentie_om_inwoners(config, datasource):
                                     else:
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot)
                                         Bereik = datasource.read_csv(abg, "Totaal", ds, mod=mod, ink=inkgr, mot=mot, subtopic="Bestemmingen")
-                                        Dezegroeplijst = Berekeningen.bereken_concurrentie(Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
+                                        Dezegroeplijst = Berekeningen.concurrentie(Matrix, Inwonersperklasse, Bereik, inkgr, inkgroepen)
                                         for i in range (len(Matrix)):
                                             if Inkomensverdeling[i][inkgroepen.index(inkgr)]>0:
                                                 Bijhoudklad = Dezegroeplijst[i] * Verdelingsmatrix[i][Groepen.index(gr)]/\

--- a/src/ikob/Ontplooiingsmogelijkhedenechteinwoners.py
+++ b/src/ikob/Ontplooiingsmogelijkhedenechteinwoners.py
@@ -4,7 +4,7 @@ import ikob.Routines as Routines
 logger = logging.getLogger(__name__)
 
 
-def bereken_potenties (Matrix, Arbeidsplaatsen, Beroepsbevolkingsverdeling, Beroepsbevolkingaandeel, inkgr, gr, inkgroepen, Groepen):
+def potenties (Matrix, Arbeidsplaatsen, Beroepsbevolkingsverdeling, Beroepsbevolkingaandeel, inkgr, gr, inkgroepen, Groepen):
     Dezegroeplijst = []
     for i in range ( len ( Matrix ) ):
         Gewogenmatrix = []
@@ -158,7 +158,7 @@ def ontplooingsmogelijkheden_echte_inwoners(config, datasource):
 
                                     Fietsmatrix = datasource.read_csv('Gewichten', f'{mod}_vk', ds, vk=vkklad, regime=regime, mot=mot)
                                     if mot == 'werk' or mot == 'winkelnietdagelijksonderwijs':
-                                        Dezegroeplijst = bereken_potenties ( Fietsmatrix, Arbeidsplaatsen, Verdelingstransmatrix,
+                                        Dezegroeplijst = potenties ( Fietsmatrix, Arbeidsplaatsen, Verdelingstransmatrix,
                                                                              Inkomenstransverdeling[inkgroepen.index(inkgr)], inkgr, gr, inkgroepen, Groepen)
                                     else:
                                         Dezegroeplijst = bereken_potenties_nietwerk(Fietsmatrix, Inwonerstotalen, Verdelingstransmatrix,
@@ -174,7 +174,7 @@ def ontplooingsmogelijkheden_echte_inwoners(config, datasource):
                                             Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
 
                                             if mot == 'werk' or mot == 'winkelnietdagelijksonderwijs':
-                                                Dezegroeplijst1 = bereken_potenties ( Matrix, Arbeidsplaatsen, Verdelingstransmatrix,
+                                                Dezegroeplijst1 = potenties ( Matrix, Arbeidsplaatsen, Verdelingstransmatrix,
                                                                                      Inkomenstransverdeling[inkgroepen.index(inkgr)], inkgr, gr, inkgroepen, Groepen)
                                             else:
                                                 Dezegroeplijst1 = bereken_potenties_nietwerk(Matrix, Inwonerstotalen, Verdelingstransmatrix,
@@ -195,7 +195,7 @@ def ontplooingsmogelijkheden_echte_inwoners(config, datasource):
                                     else:
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk',ds, vk=vk, ink=ink, regime=regime, mot=mot)
                                         if mot == 'werk' or mot == 'winkelnietdagelijksonderwijs':
-                                            Dezegroeplijst = bereken_potenties(Matrix, Arbeidsplaatsen,
+                                            Dezegroeplijst = potenties(Matrix, Arbeidsplaatsen,
                                                                                Verdelingstransmatrix,
                                                                                Inkomenstransverdeling[
                                                                                    inkgroepen.index(inkgr)],
@@ -213,7 +213,7 @@ def ontplooingsmogelijkheden_echte_inwoners(config, datasource):
                                     String = Routines.enkelegroep(mod, gr)
                                     Matrix = datasource.read_csv('Gewichten', f'{String}_vk',ds, vk=vk, ink=ink, regime=regime, mot=mot)
                                     if mot == 'werk' or mot == 'winkelnietdagelijksonderwijs':
-                                        Dezegroeplijst = bereken_potenties(Matrix, Arbeidsplaatsen, Verdelingstransmatrix,
+                                        Dezegroeplijst = potenties(Matrix, Arbeidsplaatsen, Verdelingstransmatrix,
                                                                            Inkomenstransverdeling[inkgroepen.index(inkgr)],
                                                                            inkgr, gr, inkgroepen, Groepen)
                                     else:
@@ -233,7 +233,7 @@ def ontplooingsmogelijkheden_echte_inwoners(config, datasource):
                                         for srtbr in soortbrandstof:
                                             Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
                                             if mot == 'werk' or mot == 'winkelnietdagelijksonderwijs':
-                                                Dezegroeplijst1 = bereken_potenties(Matrix, Arbeidsplaatsen,
+                                                Dezegroeplijst1 = potenties(Matrix, Arbeidsplaatsen,
                                                                                     Verdelingstransmatrix,
                                                                                     Inkomenstransverdeling[
                                                                                         inkgroepen.index(inkgr)], inkgr, gr, inkgroepen, Groepen)
@@ -257,7 +257,7 @@ def ontplooingsmogelijkheden_echte_inwoners(config, datasource):
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot)
 
                                         if mot == 'werk' or mot == 'winkelnietdagelijksonderwijs':
-                                            Dezegroeplijst = bereken_potenties ( Matrix, Arbeidsplaatsen, Verdelingstransmatrix,
+                                            Dezegroeplijst = potenties ( Matrix, Arbeidsplaatsen, Verdelingstransmatrix,
                                                                                  Inkomenstransverdeling[inkgroepen.index(inkgr)], inkgr, gr, inkgroepen, Groepen)
                                         else:
                                             Dezegroeplijst = bereken_potenties_nietwerk(Matrix, Inwonerstotalen, Verdelingstransmatrix,

--- a/src/ikob/Potentiebedrijven.py
+++ b/src/ikob/Potentiebedrijven.py
@@ -108,7 +108,7 @@ def potentie_bedrijven(config, datasource):
                                     vkklad = ''
 
                                 Fietsmatrix = datasource.read_csv('Gewichten', f'{mod}_vk', ds, vk=vkklad, regime=regime, mot=mot)
-                                Dezegroeplijst = Berekeningen.bereken_potenties (Fietsmatrix, Inwonerstransmatrix, gr, Groepen)
+                                Dezegroeplijst = Berekeningen.potenties (Fietsmatrix, Inwonerstransmatrix, gr, Groepen)
 
                                 for i in range(0, len(Fietsmatrix) ):
                                     Bijhoudlijst[i]+= round(Dezegroeplijst[i])
@@ -118,7 +118,7 @@ def potentie_bedrijven(config, datasource):
                                 if 'WelAuto' in gr:
                                     for srtbr in soortbrandstof:
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
-                                        Dezegroeplijst1 = Berekeningen.bereken_potenties(Matrix, Inwonerstransmatrix, gr, Groepen)
+                                        Dezegroeplijst1 = Berekeningen.potenties(Matrix, Inwonerstransmatrix, gr, Groepen)
                                         if srtbr == 'elektrisch':
                                             K = percentageelektrisch.get(inkgr) / 100
                                             logger.debug('aandeel elektrisch is: %s', K)
@@ -133,7 +133,7 @@ def potentie_bedrijven(config, datasource):
                                         Bijhoudlijst[i] += int(Dezegroeplijst[i])
                                 else:
                                     Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot)
-                                    Dezegroeplijst = Berekeningen.bereken_potenties(Matrix, Inwonerstransmatrix, gr, Groepen)
+                                    Dezegroeplijst = Berekeningen.potenties(Matrix, Inwonerstransmatrix, gr, Groepen)
                                     for i in range(0, len(Matrix)):
                                         Bijhoudlijst[i] += int(Dezegroeplijst[i])
                                     logger.debug('Bijhoudlijst niet fossiel is: %s', Bijhoudlijst)
@@ -141,7 +141,7 @@ def potentie_bedrijven(config, datasource):
                             elif mod == 'OV':
                                 String = Routines.enkelegroep (mod,gr)
                                 Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, vk=vk, ink=ink, regime=regime, mot=mot)
-                                Dezegroeplijst = Berekeningen.bereken_potenties ( Matrix, Inwonerstransmatrix, gr, Groepen)
+                                Dezegroeplijst = Berekeningen.potenties ( Matrix, Inwonerstransmatrix, gr, Groepen)
                                 for i in range(0, len(Matrix) ):
                                     Bijhoudlijst[i]+= round(Dezegroeplijst[i])
                             else:
@@ -151,7 +151,7 @@ def potentie_bedrijven(config, datasource):
                                 if String[0] == 'A':
                                     for srtbr in soortbrandstof:
                                         Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot, srtbr=srtbr)
-                                        Dezegroeplijst1 = Berekeningen.bereken_potenties(Matrix, Inwonerstransmatrix, gr, Groepen)
+                                        Dezegroeplijst1 = Berekeningen.potenties(Matrix, Inwonerstransmatrix, gr, Groepen)
 
                                         if srtbr == 'elektrisch':
                                             K = percentageelektrisch.get(inkgr) / 100
@@ -165,7 +165,7 @@ def potentie_bedrijven(config, datasource):
                                         Bijhoudlijst[i] += int(Dezegroeplijst[i])
                                 else:
                                     Matrix = datasource.read_csv('Gewichten', f'{String}_vk', ds, subtopic='Combinaties', vk=vk, ink=ink, regime=regime, mot=mot)
-                                    Dezegroeplijst = Berekeningen.bereken_potenties ( Matrix, Inwonerstransmatrix, gr, Groepen)
+                                    Dezegroeplijst = Berekeningen.potenties ( Matrix, Inwonerstransmatrix, gr, Groepen)
                                     for i in range ( 0, len ( Matrix ) ):
                                         Bijhoudlijst[i] += round ( Dezegroeplijst[i])
                     datasource.write_csv(Bijhoudlijst, 'Herkomsten', 'Totaal', ds, mot=mot, mod=mod, ink=inkgr)


### PR DESCRIPTION
The removes functions are not use anywhere in `ikob`. These are removed.
The prefix `bereken` is superfluous as the routines are already imported from `ikob.Berekeningen`.

This closes #28. 