### PR TITLE
Avoid suffix replacement in readers/writers routines

### DIFF
--- a/src/ikob/Routines.py
+++ b/src/ikob/Routines.py
@@ -15,7 +15,7 @@ def xlswegschrijven(matrix, filenaam, header):
     if not isinstance(filenaam, pathlib.Path):
         filenaam = pathlib.Path(filenaam)
 
-    workbook = xlsxwriter.Workbook(filenaam.with_suffix('.xlsx'))
+    workbook = xlsxwriter.Workbook(filenaam)
     worksheet = workbook.add_worksheet()
     worksheet.write_row(0, 0, header)
     for r in range(0, len(matrix)):
@@ -29,7 +29,7 @@ def xlswegschrijven_totalen(matrix, header, getallenlijst, filenaam, aantal_zone
         filenaam = pathlib.Path(filenaam)
 
     transmatrix = transponeren(matrix)
-    workbook = xlsxwriter.Workbook(filenaam.with_suffix('.xlsx'))
+    workbook = xlsxwriter.Workbook(filenaam)
     worksheet = workbook.add_worksheet()
     worksheet.write_row(0, 0, header)
     worksheet.write_column(1, 0, getallenlijst)
@@ -49,11 +49,11 @@ def csvlezen(filenaam, type_caster=float):
     # First, attempt to read without header.
     # If this fails, read with skipping the header.
     try:
-        matrix = np.loadtxt(filenaam.with_suffix(".csv"),
+        matrix = np.loadtxt(filenaam,
                             dtype=type_caster,
                             delimiter=',')
     except ValueError:
-        matrix = np.loadtxt(filenaam.with_suffix(".csv"),
+        matrix = np.loadtxt(filenaam,
                             dtype=type_caster,
                             skiprows=1,
                             delimiter=',')
@@ -83,7 +83,7 @@ def csvwegschrijven(matrix, filenaam, header=[]):
     delim = ","
     header = delim.join(header)
 
-    np.savetxt(filenaam.with_suffix(".csv"),
+    np.savetxt(filenaam,
                matrix,
                fmt=fmt,
                delimiter=delim,

--- a/src/ikob/datasource.py
+++ b/src/ikob/datasource.py
@@ -34,29 +34,29 @@ class DataSource:
         if isinstance(csv_path, dict):
             csv_path = csv_path["bestand"]
 
-        csv_path = pathlib.Path(csv_path).with_suffix('')
+        csv_path = pathlib.Path(csv_path)
         return Routines.csvlezen(csv_path, type_caster)
 
     def read_skims(self, id: str, dagsoort: str, type_caster = float):
         """Expects a filename to read, which should be located in 
         in subfolder 'dagsoort' of the global path 'Jaarinvoerdirectory'
         """
-        path = self.skims_dir / dagsoort / id
+        path = (self.skims_dir / dagsoort / id).with_suffix(".csv")
         return Routines.csvlezen(path, type_caster=type_caster)
 
     def _segs_dir(self, id, jaar, scenario):
         return self.segs_dir / scenario / (id + jaar)
 
     def write_segs_csv(self, data, id, header, jaar="", scenario=""):
-        path = self._segs_dir(id, jaar, scenario)
+        path = self._segs_dir(id, jaar, scenario).with_suffix(".csv")
         return Routines.csvwegschrijven(data, path, header=header)
 
     def write_segs_xlsx(self, data, id, header, jaar="", scenario=""):
-        path = self._segs_dir(id, jaar, scenario)
+        path = self._segs_dir(id, jaar, scenario).with_suffix(".xlsx")
         return Routines.xlswegschrijven(data, path, header)
 
     def read_segs(self, id: str, jaar="", type_caster=int, scenario=""):
-        path = self._segs_dir(id, jaar, scenario)
+        path = self._segs_dir(id, jaar, scenario).with_suffix(".csv")
         return Routines.csvlezen(path, type_caster=type_caster)
 
     def _get_base_dir(self, datatype, id):
@@ -72,15 +72,18 @@ class DataSource:
 
     def read_csv(self, datatype, id, dagsoort, regime='', subtopic='', vk='', ink='', hubnaam='', mot='', mod='', srtbr='', type_caster=float):
         base = self._get_base_dir(datatype, id)
-        bestandspad = self._make_file_path(id, mot, datatype, dagsoort, base, mod=mod, regime=regime, subtopic=subtopic, brandstof=srtbr, vk=vk, ink=ink, hubnaam=hubnaam)
-        return Routines.csvlezen(bestandspad, type_caster=type_caster)
+        path = self._make_file_path(id, mot, datatype, dagsoort, base, mod=mod, regime=regime, subtopic=subtopic, brandstof=srtbr, vk=vk, ink=ink, hubnaam=hubnaam)
+        path = path.with_suffix(".csv")
+        return Routines.csvlezen(path, type_caster=type_caster)
 
     def write_csv(self, data, datatype, id, dagsoort, header=[], regime='', subtopic='', vk='', ink='', hubnaam='', mot='', mod='', srtbr=''):
         base = self._get_base_dir(datatype, id)
-        bestandspad = self._make_file_path(id, mot, datatype, dagsoort, base, mod=mod, regime=regime, subtopic=subtopic, brandstof=srtbr, vk=vk, ink=ink, hubnaam=hubnaam)
-        return Routines.csvwegschrijven(data, bestandspad, header=header)
+        path = self._make_file_path(id, mot, datatype, dagsoort, base, mod=mod, regime=regime, subtopic=subtopic, brandstof=srtbr, vk=vk, ink=ink, hubnaam=hubnaam)
+        path = path.with_suffix(".csv")
+        return Routines.csvwegschrijven(data, path, header=header)
 
     def write_xlsx(self, data, datatype, id, dagsoort, header=[], regime='', subtopic='', vk='', ink='', hubnaam='', mot='', mod='', srtbr=''):
         base = self._get_base_dir(datatype, id)
-        bestandspad = self._make_file_path(id, mot, datatype, dagsoort, base, mod=mod, regime=regime, subtopic=subtopic, brandstof=srtbr, vk=vk, ink=ink, hubnaam=hubnaam)
-        return Routines.xlswegschrijven(data, bestandspad, header)
+        path = self._make_file_path(id, mot, datatype, dagsoort, base, mod=mod, regime=regime, subtopic=subtopic, brandstof=srtbr, vk=vk, ink=ink, hubnaam=hubnaam)
+        path = path.with_suffix(".xlsx")
+        return Routines.xlswegschrijven(data, path, header)


### PR DESCRIPTION
The read/write routines no longer set an specific suffix to the given filepath and the routines expect the file suffix to be set externally. This allows to also read files of these types with different suffix.

Closes #32.