### PR TITLE
Return CSV files as numpy arrays

### DIFF
--- a/src/ikob/Routines.py
+++ b/src/ikob/Routines.py
@@ -57,7 +57,7 @@ def csvlezen(filenaam, type_caster=float):
                             dtype=type_caster,
                             skiprows=1,
                             delimiter=',')
-    return matrix.tolist()
+    return matrix
 
 
 def csvintlezen(filenaam):


### PR DESCRIPTION
The data read from CSV files can be kept as numpy arrays. This is OK and provides an initial point for subsequent changes to adopt numpy arrays in more operations.

Contributes to #30.