### PR TITLE
Return early after file dialog was cancelled

### DIFF
--- a/src/ikob/ikobconfig.py
+++ b/src/ikob/ikobconfig.py
@@ -119,6 +119,11 @@ class ConfigApp(tk.Tk):
             initialfile=_projectFilename(project_name(config)),
             filetypes=[("project file", ".json")],
         )
+
+        # The filename remains empty when the dialog is cancelled.
+        if filename == "":
+            return
+
         filename = _projectFilename(filename, make_safe=False)
         try:
             saveConfig(filename, config)


### PR DESCRIPTION
If the file dialog was cancelled by the user, the resulting filename is an empty string. In this case `cmdOpslaanProject` should return early. This avoids writing an empty file `.json` in the selected directory and avoids displaying a message box indicating the file was saved successfully.

Closes #59 