### PR TITLE
Ensure logged message are visible over stdout when running GUIs

### DIFF
--- a/scripts/ikobconfig.bat
+++ b/scripts/ikobconfig.bat
@@ -13,7 +13,7 @@ if exist %venvdir% (
 )
 
 :: Launch the config GUI.
-python src\ikob\ikobconfig.py
+python src\ikob\ikobconfig.py --verbose
 goto :DONE
 
 :VIRTUALENV_NOT_PRESENT

--- a/scripts/ikobrunner.bat
+++ b/scripts/ikobrunner.bat
@@ -13,7 +13,7 @@ if exist %venvdir% (
 )
 
 :: Launch the config GUI.
-python src\ikob\ikobrunner.py
+python src\ikob\ikobrunner.py --verbose
 goto :DONE
 
 :VIRTUALENV_NOT_PRESENT

--- a/src/ikob/ikobconfig.py
+++ b/src/ikob/ikobconfig.py
@@ -139,8 +139,10 @@ class ConfigApp(tk.Tk):
                 message="Configuratie opgeslagen.")
 
 
-def main():
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+def main(verbose=False):
+    if verbose:
+        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
     if not validate.validateTemplate(default_configuration_definition()):
         messagebox.showerror(
             title="Fout",
@@ -152,4 +154,15 @@ def main():
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="ikobconfig", description="Launch the IKOB config GUI."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Display logging messages over stdout.",
+    )
+    args = parser.parse_args()
+
     main()

--- a/src/ikob/ikobrunner.py
+++ b/src/ikob/ikobrunner.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import sys
 import threading
@@ -173,11 +174,23 @@ class ConfigApp(Tk):
                     title="Fout", message="Het bestand kan niet worden geladen.")
 
 
-def main():
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+def main(verbose=False):
+    if verbose:
+        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     App = ConfigApp()
     App.mainloop()
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        prog="ikobrunner", description="Launch the IKOB runner GUI."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Display logging messages over stdout.",
+    )
+    args = parser.parse_args()
+
+    main(args.verbose)


### PR DESCRIPTION
The helper scripts default to running the GUIs in with `--verbose` set to have some sense of progress through displaying logged messages at the `INFO` level.

To have some control over the verbosity a tiny `ArgumentParser` is defined for the `ikobconfig.py` and `ikobrunner.py` scripts such that users running these GUIs from the command-line can easily toggle their preference regarding the verbosity level.

The additional benefit is that these scripts now print usage information, e.g. `python src/ikob/ikobrunner.py -h`.

Closes #60 