### PR TITLE
Attempt to recover from known config changes

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,129 @@
+import json
+import pathlib
+
+from ikob.configuration_definition import (try_fix_incompatible_configuration,
+                                           validate_config)
+from ikob.ikobconfig import loadConfig
+
+old_config = """
+{
+  "TVOM": {
+    "werk": {
+      "middellaag": 9.0,
+      "laag": 12.0,
+      "hoog": 4.0,
+      "middelhoog": 6.0
+    },
+    "overig": {
+      "middellaag": 10.9,
+      "laag": 15.5,
+      "hoog": 4.8,
+      "middelhoog": 7.25
+    }
+  },
+  "project": {
+    "schatten_of_bekend": [
+      "geschat"
+    ],
+    "conc_afstand": [
+      "concurrentie"
+    ],
+    "naam": "Vlaanderen",
+    "beprijzingsregime": "Basis",
+    "paden": {
+      "segs_directory": "tests/vlaanderen/SEGS",
+      "skims_directory": "tests/vlaanderen/skims",
+      "output_directory": "tests/vlaanderen/"
+    },
+    "verstedelijkingsscenario": "2023",
+    "welke_groepen": [
+      "alle groepen"
+    ],
+    "motieven": [
+      "werk"
+    ],
+    "ketens": {
+      "gebruiken": false,
+      "naam hub": ""
+    },
+    "welke_inkomensgroepen": [
+      "laag",
+      "middellaag",
+      "middelhoog",
+      "hoog"
+    ]
+  },
+  "verdeling": {
+    "GratisOVpercentage": 0.03,
+    "kunstmab": {
+      "gebruiken": false,
+      "bestand": ""
+    },
+    "parkeerkosten": {
+      "gebruiken": false,
+      "bestand": ""
+    },
+    "Percelektrisch": {
+      "middellaag": 0.0,
+      "laag": 0.0,
+      "hoog": 0.0,
+      "middelhoog": 0.0
+    },
+    "additionele_kosten": {
+      "gebruiken": false,
+      "bestand": ""
+    }
+  },
+  "skims": {
+    "Kosten auto fossiele brandstof": {
+      "variabele kosten": 16.0,
+      "kmheffing": 0.0
+    },
+    "Kosten elektrische auto": {
+      "variabele kosten": 5.0,
+      "kmheffing": 0.0
+    },
+    "varkostenga": {
+      "GeenAuto": 0.33,
+      "GeenRijbewijs": 2.4
+    },
+    "pricecap": {
+      "gebruiken": false,
+      "getal": 9999.0
+    },
+    "OV kostenbestand": {
+      "gebruiken": false
+    },
+    "parkeerzoektijden_bestand": "tests/vlaanderen/SEGS/Parkeerzoektijd.csv",
+    "OV kosten": {
+      "kmkosten": 12.0,
+      "starttarief": 75.0
+    },
+    "dagsoort": [
+      "Restdag"
+    ],
+    "tijdkostenga": {
+      "GeenAuto": 0.05,
+      "GeenRijbewijs": 0.4
+    }
+  }
+}"""
+
+
+def test_auto_fix_config():
+    config = json.loads(old_config)
+
+    msg = "The old configuration should initially be reported as invalid."
+    assert not validate_config(config), msg
+
+    config = try_fix_incompatible_configuration(config)
+
+    msg = "The configuration should be OK after attempted fix."
+    assert validate_config(config), msg
+
+
+def test_load_fixable_config(tmpdir):
+    tmpdir = pathlib.Path(tmpdir)
+    config_file = (tmpdir / "test.json")
+    config_file.write_text(old_config)
+    loadConfig(config_file)


### PR DESCRIPTION
When changes are introduced to the GUI, e.g. by moving configuration items to other tabs, the corresponding configuration files are altered too. This causes old configuration files to be mark as invalid inputs, as these are missing the new GUI definitions and therefore do not match with what the validator expects.

Since the changes in GUI definitions are well defined, as typically only some keys are moved within the configuration dictionaries, we can try to recover from such invalid inputs by shifting these dictionary keys accordingly. By doing so, we can maintain backward compatibility with older configuration files.

Any attempt that is made to resolve such invalid configuration files are logged to notify the user. To update old configuration files, they can be loaded with `ikobconfig` and saved again. This should update the configuration accordingly.

Closes #58 