### PR TITLE
Add log message when files are written to disk

### DIFF
--- a/src/ikob/datasource.py
+++ b/src/ikob/datasource.py
@@ -236,6 +236,7 @@ class DataSource:
         return data
 
     def store(self):
+        logger.info("Writing output for data: %s.", self.datatype.value)
         for key, data in self.cache.items():
             self.write_csv(data, key)
 

--- a/src/ikob/ikobrunner.py
+++ b/src/ikob/ikobrunner.py
@@ -27,6 +27,7 @@ def run_scripts(project_file, skip_steps=None):
     logger.info("Reading project file: %s.", project_file)
     config = getConfigFromArgs(project_file)
 
+    logger.info("Starting simulations...")
     if not skip_steps:
         skip_steps = [False] * 8
 
@@ -72,9 +73,12 @@ def run_scripts(project_file, skip_steps=None):
     else:
         competition_citizens = DataSource(config, DataType.COMPETITION)
 
+    logger.info("All simulations are completed.")
+
     # TODO: For now all files are written to disk to assert their contents in
     # end-to-end testing. Ultimately only files that are essential outputs
     # should persist.
+    logger.info("Writing output to disk...")
     for container in [
             travel_time,
             single_weights,


### PR DESCRIPTION
To more clearly indicate the transition between simulation and writing results to disk two kinds of messages are added to the info logging:

* A `DataSource` instance will report a message whenever its `store` method is invoked to write data to disk.
* A message is reported after all simulation steps are completed within the `ikobrunner.py` driving script.

Then the logging indicates whenever files are being written to disk. For test case `vlaanderen` this looks like:

```
INFO     ikob.ikobrunner:ikobrunner.py:76 All simulations are completed.
INFO     ikob.ikobrunner:ikobrunner.py:81 Writing output to disk...
INFO     ikob.datasource:datasource.py:239 Writing output for data: ervarenreistijd.
INFO     ikob.datasource:datasource.py:239 Writing output for data: gewichten.
INFO     ikob.datasource:datasource.py:239 Writing output for data: gewichten.
INFO     ikob.datasource:datasource.py:239 Writing output for data: bestemmingen.
INFO     ikob.datasource:datasource.py:239 Writing output for data: herkomsten.
INFO     ikob.datasource:datasource.py:239 Writing output for data: concurrentie.
INFO     ikob.datasource:datasource.py:239 Writing output for data: concurrentie.
```

This closes #75.

