### PR TITLE
Exclude Python 3.13.0 from supported versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "ikob"
 version = "0.0.1"
 description = "IKOB"
 readme = "README.md"
-requires-python = ">= 3.12"
+# In version 3.13.0 the GUI fails to launch: https://github.com/Stichting-CROW/ikob/issues/74.
+requires-python = ">= 3.12, != 3.13.0"
 license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",


### PR DESCRIPTION
When trying to install IKOB using 3.13.0 the installation will fail, with a message like:

```
pip install -e .[dev]
...
ERROR: Package 'ikob' requires a different Python: 3.13.0 not in '!=3.13.0,>=3.12'
```

By failing the installation for this specific version of Python, we can avoid the GUI issues reported in #74.
The problem is most-likely resolved with the upcoming Python 3.13.1 release, so this closes #74.