### PR TITLE
Update Python version notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ The first method relies on helper scripts provided in [`scripts`](scripts/),
 while the second method follows a manual installation approach. 
 
 > [!IMPORTANT]
-> Before proceeding make sure [Python](https://www.python.org/) is installed
-> and available on your system. To install and run IKOB requires your system
-> to have at least Python 3.12.
+> Before proceeding make sure [Python](https://www.python.org/) is installed on the system.
+> IKOB supports versions 3.12.x and 3.13.1 (or newer).
+> For Windows users relying on Python installers, make sure to enable the checkbox `"Add python.exe to PATH"` during installation.
 
-> [!WARNING]
-> There is a known issue when working with Python 3.13.0 (see
-> [#74](https://github.com/Stichting-CROW/ikob/issues/74)) and Python 3.12.x is
-> recommended for the meantime.
+> [!CAUTION]
+> There is a known issue when working with Python version **3.13.0** (see [#74](https://github.com/Stichting-CROW/ikob/issues/74)).
+> Users should therefore use for versions **3.12.x** or **>= 3.13.1**.
 
 ### Using helper scripts
 


### PR DESCRIPTION
This is an attempt to make the Python versions and PATH description in the README somewhat more clear. I'll leave it to Redmer to decide if this actually makes it more understandable though.

Closes #90.