### PR TITLE
Convert `fiets or E-fiets` from checklist to checkbox

### DIFF
--- a/src/ikob/config/validate.py
+++ b/src/ikob/config/validate.py
@@ -109,6 +109,8 @@ def validateConfigWithTemplate(config, template, strict=False):
                False - Configuratie klopt niet.
     """
     templatekeys = [key for key in template.keys() if key != "label"]
+    if not isinstance(config, dict):
+        return False
     if strict and set(config.keys()) != set(templatekeys):
         return False
     for key in templatekeys:

--- a/src/ikob/config/validate.py
+++ b/src/ikob/config/validate.py
@@ -82,13 +82,17 @@ def _validateItems(values, template):
     if type(values) is not list:
         return False
     for item in values:
-        if item not in template.items:
+        if item not in template["items"]:
             return False
     return True
 
 
+def _validateBox(value, template):
+    return value in [True, False]
+
+
 def _validateChoice(value, template):
-    if value not in template.items:
+    if value not in template["items"]:
         return False
     return True
 
@@ -117,11 +121,13 @@ def validateConfigWithTemplate(config, template, strict=False):
                 "number": _validateNumber,
                 "directory": _validateText,
                 "file": _validateText,
-                "checkbox": _validateItems,
+                "checkbox": _validateBox,
                 "checklist": _validateItems,
                 "choice": _validateChoice,
             }
-            check.get(template[key]["type"], _false)(config[key], template[key])
+            if not check.get(template[key]["type"], _false)(config[key], template[key]):
+                return False
         elif type(template[key]) is dict:
-            return validateConfigWithTemplate(config[key], template[key], strict=strict)
+            if not validateConfigWithTemplate(config[key], template[key], strict=strict):
+                return False
     return True

--- a/src/ikob/configuration_definition.py
+++ b/src/ikob/configuration_definition.py
@@ -28,8 +28,9 @@ def config_item(
         default = default_values.get(data_type, default)
 
     # The default value is expected as list when more items are present.
-    if items and isinstance(default, str):
-        default = [default]
+    if data_type != DataType.CHOICE:
+        if items and isinstance(default, str):
+            default = [default]
 
     dictionary = {"label": label, "type": data_type.value, "default": default}
 

--- a/src/ikob/configuration_definition.py
+++ b/src/ikob/configuration_definition.py
@@ -379,15 +379,17 @@ def transfer_to_advanced_tab(config):
 
     Introduced in commit `6c6684c`.
     """
-    if "geavanceerd" in config:
-        # Cannot fix: advanced already present.
-        return config
-
     msg = 'Trying to auto fix "geavanceerd" configuration entry.'
     logger.warning(msg)
 
-    config["geavanceerd"] = {}
+    # There is nothing to fix if the deprecated key is not present.
+    if "verdeling" not in config:
+        return config
+
     for key in ["kunstmab", "parkeerkosten", "additionele_kosten"]:
+        if key not in config["verdeling"]:
+            continue
+
         config["geavanceerd"][key] = config["verdeling"].pop(key)
 
     return config

--- a/src/ikob/configuration_definition.py
+++ b/src/ikob/configuration_definition.py
@@ -72,12 +72,13 @@ def default_project_tab():
             default="werk",
             items=["werk", "winkeldagelijkszorg", "winkelnietdagelijksonderwijs", "sociaal-recreatief"],
         ),
-        "fiets of E-fiets": config_item(
-            "Rekenen met fiets of E-fiets (slechts één aanklikken)",
-            DataType.CHECKLIST,
-            default="Fiets",
-            items=["Fiets", "E-fiets"],
-        ),
+        "fiets of E-fiets": {
+            "label": "Rekenen met Fiets of E-fiets",
+            "E-fiets": config_item(
+                "Met E-fiets",
+                DataType.CHECKBOX,
+            ),
+        },
         "welke_inkomensgroepen": config_item(
             "Welke inkomensgroepen moeten worden meegenomen",
             DataType.CHECKLIST,

--- a/src/ikob/configuration_definition.py
+++ b/src/ikob/configuration_definition.py
@@ -415,6 +415,12 @@ def transfer_to_chains_tab(config):
     for key in ["ketens"]:
         config[group][translation[key]] = config["project"].pop(key)
 
+    # Add missing bestemmingslijst entry.
+    config[group]["bestemmingslijst"] = {
+        "gebruiken": False,
+        "bestand": "",
+    }
+
     return config
 
 

--- a/src/ikob/configuration_definition.py
+++ b/src/ikob/configuration_definition.py
@@ -366,7 +366,11 @@ def try_fix_incompatible_configuration(config):
     Some configuration changes can be automatically resolved to
     maintain backward compatibility.
     """
-    fixers = [transfer_to_advanced_tab, transfer_to_chains_tab]
+    fixers = [
+        transfer_to_advanced_tab,
+        transfer_to_chains_tab,
+        fiets_checklist_to_checkbox,
+    ]
 
     for fixer in fixers:
         config = fixer(config)
@@ -425,6 +429,26 @@ def transfer_to_chains_tab(config):
         "bestand": "",
     }
 
+    return config
+
+
+def fiets_checklist_to_checkbox(config):
+    """Update decremented fiets checklist into checkbox."""
+
+    fiets_of_efiets = config["project"]["fiets of E-fiets"]
+    is_deprecated = isinstance(fiets_of_efiets, list)
+
+    if not is_deprecated:
+        return config
+
+    # Since chancing the configuration from a checklist into a
+    # checkbox, selecting multiple entries are no longer supported,
+    # so multiple entries are not attempted to be fixed.
+    if len(fiets_of_efiets) > 1:
+        return config
+
+    is_enabled = fiets_of_efiets == ["E-fiets"]
+    config["project"]["fiets of E-fiets"] = {"E-fiets": is_enabled}
     return config
 
 

--- a/src/ikob/single_weights.py
+++ b/src/ikob/single_weights.py
@@ -42,7 +42,7 @@ def calculate_single_weights(config, generalised_travel_time: DataSource) -> Dat
     # Vaste waarden
     incomes = ["hoog", "middelhoog", "middellaag", "laag"]
     preferences = ["Auto", "Neutraal", "Fiets", "OV"]
-    modalities_bike = project_config["fiets of E-fiets"]
+    modalities_bike = ["E-fiets"] if project_config["fiets of E-fiets"]["E-fiets"] else ["Fiets"]
     fuel_kinds = ["fossiel", "elektrisch"]
 
     weights = DataSource(config, DataType.WEIGHTS)

--- a/tests/eb-eindhoven/eb-eindhoven.json
+++ b/tests/eb-eindhoven/eb-eindhoven.json
@@ -25,6 +25,7 @@
   "ketens": {
     "chains": {
       "gebruiken": false,
+      "bestand": "",
       "naam hub": ""
     },
     "bestemmingslijst": {

--- a/tests/eb-eindhoven/eb-eindhoven.json
+++ b/tests/eb-eindhoven/eb-eindhoven.json
@@ -43,9 +43,9 @@
     "motieven": [
       "werk"
     ],
-    "fiets of E-fiets": [
-        "Fiets"
-    ],
+    "fiets of E-fiets": {
+        "E-fiets": false
+    },
     "naam": "EB_Eindhoven_Basis_nw",
     "welke_inkomensgroepen": [
       "laag",

--- a/tests/eindhoven-500/eindhoven-500.json
+++ b/tests/eindhoven-500/eindhoven-500.json
@@ -97,6 +97,7 @@
   "ketens": {
     "chains": {
       "gebruiken": false,
+      "bestand": "",
       "naam hub": ""
     },
     "bestemmingslijst": {

--- a/tests/eindhoven-500/eindhoven-500.json
+++ b/tests/eindhoven-500/eindhoven-500.json
@@ -72,9 +72,9 @@
     "motieven": [
       "werk"
     ],
-    "fiets of E-fiets": [
-        "Fiets"
-    ],
+    "fiets of E-fiets": {
+        "E-fiets": false
+    },
     "beprijzingsregime": "Basis"
   },
   "geavanceerd": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import pytest
 
 from ikob.configuration_definition import try_fix_incompatible_configuration, validate_config
 from ikob.ikobconfig import loadConfig
@@ -125,3 +126,28 @@ def test_load_fixable_config(tmpdir):
     config_file = tmpdir / "test.json"
     config_file.write_text(old_config)
     loadConfig(config_file)
+
+
+@pytest.mark.parametrize(
+    "gui_tab, key, invalid_value",
+    [
+        ("project", "fiets of E-fiets", ["not-allowed-value"]),
+        ("project", "fiets of E-fiets", "not-allowed-value"),
+    ],
+)
+def test_detect_invalid_choice(tmpdir, gui_tab, key, invalid_value):
+    # Assert the original file loads properly.
+    filename = pathlib.Path("tests/vlaanderen/vlaanderen.json")
+    _ = loadConfig(filename)
+
+    # Insert invalid entries.
+    config = json.loads(filename.read_text())
+    config[gui_tab][key] = invalid_value
+
+    tmpfile = pathlib.Path(tmpdir, "config.json")
+    with open(tmpfile, "w") as fp:
+        json.dump(config, fp)
+
+    # Loading with an invalid entry should fail.
+    with pytest.raises(ValueError):
+        loadConfig(tmpfile)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+
 import pytest
 
 from ikob.configuration_definition import try_fix_incompatible_configuration, validate_config
@@ -33,9 +34,9 @@ old_config = """
     "motieven": [
       "werk"
     ],
-    "fiets of E-fiets": {
-        "E-fiets": false
-    },
+    "fiets of E-fiets": [
+        "Fiets"
+    ],
     "ketens": {
       "gebruiken": false,
       "bestand": "",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,7 @@ old_config = """
     ],
     "ketens": {
       "gebruiken": false,
+      "bestand": "",
       "naam hub": ""
     },
     "welke_inkomensgroepen": [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,9 +33,9 @@ old_config = """
     "motieven": [
       "werk"
     ],
-    "fiets of E-fiets": [
-        "Fiets"
-    ],
+    "fiets of E-fiets": {
+        "E-fiets": false
+    },
     "ketens": {
       "gebruiken": false,
       "bestand": "",
@@ -130,20 +130,20 @@ def test_load_fixable_config(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "gui_tab, key, invalid_value",
+    "gui_tab, key, item, invalid_value",
     [
-        ("project", "fiets of E-fiets", ["not-allowed-value"]),
-        ("project", "fiets of E-fiets", "not-allowed-value"),
+        ("project", "fiets of E-fiets", "E-fiets", ["not-allowed-value"]),
+        ("project", "fiets of E-fiets", "E-fiets", "not-allowed-value"),
     ],
 )
-def test_detect_invalid_choice(tmpdir, gui_tab, key, invalid_value):
+def test_detect_invalid_choice(tmpdir, gui_tab, key, item, invalid_value):
     # Assert the original file loads properly.
     filename = pathlib.Path("tests/vlaanderen/vlaanderen.json")
     _ = loadConfig(filename)
 
     # Insert invalid entries.
     config = json.loads(filename.read_text())
-    config[gui_tab][key] = invalid_value
+    config[gui_tab][key][item] = invalid_value
 
     tmpfile = pathlib.Path(tmpdir, "config.json")
     with open(tmpfile, "w") as fp:

--- a/tests/vlaanderen-with-parking-cost/vlaanderen-with-parking-cost.json
+++ b/tests/vlaanderen-with-parking-cost/vlaanderen-with-parking-cost.json
@@ -97,6 +97,7 @@
   "ketens": {
     "chains": {
       "gebruiken": false,
+      "bestand": "",
       "naam hub": ""
     },
     "bestemmingslijst": {

--- a/tests/vlaanderen-with-parking-cost/vlaanderen-with-parking-cost.json
+++ b/tests/vlaanderen-with-parking-cost/vlaanderen-with-parking-cost.json
@@ -25,9 +25,9 @@
     "motieven": [
       "werk"
     ],
-    "fiets of E-fiets": [
-        "Fiets"
-    ],
+    "fiets of E-fiets": {
+        "E-fiets": false
+    },
     "welke_inkomensgroepen": [
       "laag",
       "middellaag",

--- a/tests/vlaanderen/vlaanderen.json
+++ b/tests/vlaanderen/vlaanderen.json
@@ -97,6 +97,7 @@
   "ketens": {
     "chains": {
       "gebruiken": false,
+      "bestand": "",
       "naam hub": ""
     },
     "bestemmingslijst": {

--- a/tests/vlaanderen/vlaanderen.json
+++ b/tests/vlaanderen/vlaanderen.json
@@ -25,9 +25,9 @@
     "motieven": [
       "werk"
     ],
-    "fiets of E-fiets": [
-        "Fiets"
-    ],
+    "fiets of E-fiets": {
+        "E-fiets": false
+    },
     "welke_inkomensgroepen": [
       "laag",
       "middellaag",


### PR DESCRIPTION
The main contribution of this patch is to change the configuration option `fiets of E-fiets` from a checklist into a checkbox as requested by @HansVoerknecht. In the GUI this change is represented by the change of two separate checkboxes, one for `fiets` and `E-fiets`, into a single checkbox to enable running with `E-fiets` rather than running with `Fiets`. This change also avoids the possible invalid input scenario where a user might select both `Fiets` and `E-fiets`, which is a configuration variant that is not supported within the internals of the calculations.

The attached images highlight the visual change:

<details>
<summary>Before</summary>

![before](https://github.com/user-attachments/assets/400764ca-da99-4b47-86ec-c6e3aa707d74)

</details>

<details>
<summary>After</summary>

![after](https://github.com/user-attachments/assets/0557c00c-582f-4ae9-873a-05ced750e789)

</details>

---

During the implementation of this small feature request, multiple bugs surfaced that were contained in the custom handling of the input (json) validation code and the encountered problems are resolved directly as part of this pull request.

The errors encountered within the custom configuration definition and validation highlight the importance of considering the enhancement suggested in #84, and then specifically the suggestion to adopt `pydantic` for configuration definition and validation. I believe that by adopting such a tool (or similar) we can remove a bunch of the custom configuration definition/validation and replace with clearly defined `BaseModel` definitions paired with solid input validation, avoiding the type of errors encountered in this PR.

---


@HansVoerknecht In your review can you verify the GUI changes are as you intended and the obtained results are as desired? Please also check running with `E-fiets` to ensure all is working OK.

@redmer Could you take a brief look at the code changes in general? It would be nice if we at some point can refactor the input validation, that would simplify things a lot I think.