### PR TITLE
Support Python versions >= 3.13.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 # The ikobconfig and ikobrunner GUI require tk.
 RUN apt-get update -y

--- a/README.md
+++ b/README.md
@@ -12,16 +12,12 @@ So, the further away an amenity (like a job location) is, the less it will count
 
 The next section illustrates two approaches of setting up IKOB on your machine.
 The first method relies on helper scripts provided in [`scripts`](scripts/),
-while the second method follows a manual installation approach. 
+while the second method follows a manual installation approach.
 
 > [!IMPORTANT]
 > Before proceeding make sure [Python](https://www.python.org/) is installed on the system.
-> IKOB supports versions 3.12.x and 3.13.1 (or newer).
+> IKOB supports versions 3.13.1 and newer.
 > For Windows users relying on Python installers, make sure to enable the checkbox `"Add python.exe to PATH"` during installation.
-
-> [!CAUTION]
-> There is a known issue when working with Python version **3.13.0** (see [#74](https://github.com/Stichting-CROW/ikob/issues/74)).
-> Users should therefore use for versions **3.12.x** or **>= 3.13.1**.
 
 ### Using helper scripts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 description = "IKOB"
 readme = "README.md"
 # In version 3.13.0 the GUI fails to launch: https://github.com/Stichting-CROW/ikob/issues/74.
-requires-python = ">= 3.12, != 3.13.0"
+requires-python = ">= 3.13.1"
 license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",


### PR DESCRIPTION
This version is supported (per the README) so also enforce its passing of the tests during CI actions.

@redmer What do you think: should we run both version in CI or is that a bit excessive? We could also opt to just run 3.13 and not spend the time (and energy) for running actions on 3.12 too.