### PR TITLE
Update constants.py

### DIFF
--- a/src/ikob/constants.py
+++ b/src/ikob/constants.py
@@ -54,7 +54,7 @@ def _daily_shopping_constants(modality, preference):
     alpha = 0.225
     omega = 12.5
     scaling = 1
-    if modality == "Fiets" or "EFiets":
+    if modality in ("Fiets", "EFiets"):
         omega = 10
         if preference == "Fiets":
             omega = 12.5
@@ -70,7 +70,7 @@ def _non_daily_shopping_constants(modality, preference):
     alpha = 0.225
     omega = 20
     scaling = 1
-    if modality == "Fiets" or "EFiets":
+    if modality in ("Fiets","EFiets"):
         omega = 15
         if preference == "Fiets":
             omega = 20


### PR DESCRIPTION
[if modality == "Fiets" or "EFiets"] always returns true, since "EFiets" is TRUE by default. Changed it to [if modality in ("Fiets", "EFiets")