### PR TITLE
chore(docs): update action dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,19 @@
-name: Documentation
+name: Build and deploy documentation
+
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
-      - main
     paths:
-      - docs
+      - docs/**
+      - .github/workflows/docs.yml
+
 permissions:
   contents: read
   pages: write
   id-token: write
+
 jobs:
   deploy:
     environment:
@@ -17,15 +21,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/configure-pages@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install zensical
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment


### PR DESCRIPTION
This PR updates GH Actions dependencies.

Also, PR #147 didn't contain the right push triggers to start the build and deploy. This PR tries to fix that.